### PR TITLE
Add support for limits per IP address and auth token

### DIFF
--- a/.github/scripts/hide-comments.sh
+++ b/.github/scripts/hide-comments.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+# This script finds all issue comments on a PR that match a specific prefix and
+# have been posted by a specific user and minimizes them.
+
+die() {
+  # We don't ever return a non-zero status code because GitHub actions exits out
+  # of the workflow if any of the commands exit with a non-zero status code.
+  echo "$@"
+  exit 0
+}
+
+which jq &> /dev/null || die "jq must be installed"
+which curl &> /dev/null || die "curl must be installed"
+
+gh_api_url=$1
+gh_gql_url=$2
+gh_token=$3
+gh_repo=$4
+gh_pr_number=$5
+gh_comment_prefix=$6
+gh_user_login=$7
+
+# List all comments for the Pull Request we're working on.
+echo "Listing all issue comments for PR #$gh_pr_number"
+curl -fsSX GET \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${gh_token}" \
+  --output response.json \
+  "${gh_api_url}/repos/${gh_repo}/issues/${gh_pr_number}/comments" \
+|| die "Failed to list all issue comments for PR #${gh_pr_number}"
+
+[[ $(jq 'length' response.json) -gt 0 ]] || die "No comments found for PR #${gh_pr_number}, nothing to hide"
+
+# Use jq to find all comments we've posted before (matches against the action
+# runner's user login and a partial string match on comment body).
+cat response.json \
+| jq \
+  --arg user_login "$gh_user_login" \
+  --arg pfx "$gh_comment_prefix" \
+  '.[] |
+    select(.user.login == $user_login) |
+    select(.body | startswith($pfx)) |
+    .node_id
+  ' > comment_ids.txt \
+|| die 'Failed to parse issue comments response'
+
+[[ $(cat comment_ids.txt | wc -l) -gt 0 ]] || die "No comments matching message prefix and github user id ($gh_user_login) found"
+
+# Build GitHub GraphQL queries for each comment id. Because GitHub doesn't
+# return whether a comment is already hidden or not in its comment listing
+# endpoint, we have to hide all of them.
+while IFS= read -r node_id; do
+  echo "mutation { minimizeComment(input: {subjectId: $node_id, classifier: OUTDATED}) { minimizedComment { isMinimized } } }" >> graphql.txt
+done <<< "$(cat comment_ids.txt)"
+
+# Parse it through jq to build a valid json object.
+while IFS= read -r graphql; do
+  jq --null-input -c --arg q "$graphql" '{"query": $q}' >> hide_queries.json \
+  || die "Failed to create http minimizeComment query for graphql query $graphql"
+done <<< "$(cat graphql.txt)"
+
+# Hide Comments
+echo 'Issuing GraphQL calls to GitHub to hide previous comments'
+while IFS= read -r hide_query; do
+  curl -fsSX POST \
+    -H "Authorization: Bearer $gh_token" \
+    -d "$hide_query" \
+    "${gh_gql_url}" \
+  || die "Failed to issue request to minimize comment"
+done <<< "$(cat hide_queries.json)"

--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -1,0 +1,102 @@
+
+name: benchstat
+
+on:
+  - pull_request
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  benchstat:
+    strategy:
+      matrix:
+        go: ["1.21"]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: ${{ matrix.go }}
+          cache: false
+      - name: Checkout out code
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        with:
+          fetch-depth: '0'
+      - name: Determine go cache key
+        id: go-cache-key
+        run: |
+          echo "key=${{ runner.os }}-go-${{ matrix.go }}-${{ hashFiles('**/go.sum', './Makefile') }}" >> "$GITHUB_OUTPUT"
+          echo "restore-key=${{ runner.os }}-go-${{ matrix.go }}" >> "$GITHUB_OUTPUT"
+      - name: Determine Go cache paths
+        id: go-cache-paths
+        run: |
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-bin=$(go env GOPATH)/bin" >> "$GITHUB_OUTPUT"
+      - name: Cache
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3.3.2
+        with:
+          path: |
+            ${{ steps.go-cache-paths.outputs.go-mod }}
+            ${{ steps.go-cache-paths.outputs.go-bin }}
+            ${{ steps.go-cache-paths.outputs.go-build }}
+          key: ${{ steps.go-cache-key.outputs.key }}
+          restore-keys: |
+            ${{ steps.go-cache-key.outputs.restore-key }}
+      - name: Install tools
+        run: |
+          go mod download
+          make tools
+      - name: Bench New
+        run: |
+          # Run benchmarks without running any tests
+          go test -bench=. -count=10 -run=^# | tee new.txt
+      - name: Bench Old
+        run: |
+          git checkout "${GITHUB_BASE_REF}"
+          go mod download
+          # Run benchmarks without running any tests
+          go test -bench=. -count=10 -run=^# | tee old.txt
+          git checkout "${GITHUB_HEAD_REF}"
+      - name: Benchstat
+        run: |
+          benchstat old.txt new.txt | tee benchstat.txt
+      - name: Post benchstat
+        run: |
+          gh_comment_prefix='Benchstat'
+          gh_user_login='github-actions[bot]'
+          echo 'Hiding previous PR comments'
+          ./.github/scripts/hide-comments.sh \
+            "$GITHUB_API_URL" \
+            "$GITHUB_GRAPHQL_URL" \
+            "${{ secrets.GITHUB_TOKEN }}" \
+            "$GITHUB_REPOSITORY" \
+            "${{ github.event.pull_request.number }}" \
+            "$gh_comment_prefix" \
+            "$gh_user_login"
+
+          echo 'Generate github comment'
+          cat << EOF > github-comment.txt
+          ${gh_comment_prefix} - old: \`${GITHUB_BASE_REF}\` new: \`${GITHUB_HEAD_REF}\` @ ${{ github.event.pull_request.head.sha }}
+
+          \`\`\`
+          $(cat benchstat.txt)
+          \`\`\`
+          EOF
+
+          # Parse it through jq to build a valid json object.
+          jq --null-input \
+            --arg comment "$(cat github-comment.txt)" \
+            '{"body": $comment}' > body.json
+
+          # Post comment on PR.
+          echo "Posting new comment under PR #${{ github.event.pull_request.number }}"
+          curl -sX POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -d @body.json \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/issues/${{ github.event.pull_request.number }}/comments"

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ all: test
 tools:
 	go install github.com/hashicorp/copywrite@v0.15.0
 	go install mvdan.cc/gofumpt@v0.3.1
+	go install golang.org/x/perf/cmd/benchstat@latest
 
 .PHONY: test
 test:

--- a/limiter_bench_test.go
+++ b/limiter_bench_test.go
@@ -52,6 +52,6 @@ func BenchmarkAllow(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
 		rIdx = i % numResources
-		l.Allow(resources[rIdx], action)
+		l.Allow(resources[rIdx], action, "127.0.0.1")
 	}
 }

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -174,9 +174,10 @@ func TestNewLimiter(t *testing.T) {
 }
 
 type allowTestRequest struct {
-	resource string
-	action   string
-	ip       string
+	resource  string
+	action    string
+	ip        string
+	authToken string
 
 	expectAllowed bool
 	expectErr     error
@@ -211,6 +212,14 @@ func TestLimiterAllow(t *testing.T) {
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 25,
+					Period:      time.Minute,
+				},
 			},
 			[]Option{},
 			[]allowTestRequest{
@@ -223,9 +232,9 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource",
 							Action:      "action",
-							Per:         LimitPerIPAddress,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
-							MaxRequests: 50,
+							MaxRequests: 25,
 							Period:      time.Minute,
 						},
 						used: 1,
@@ -253,6 +262,14 @@ func TestLimiterAllow(t *testing.T) {
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 25,
+					Period:      time.Minute,
+				},
 			},
 			[]Option{},
 			[]allowTestRequest{
@@ -274,7 +291,7 @@ func TestLimiterAllow(t *testing.T) {
 					Action:      "action",
 					Per:         LimitPerTotal,
 					Unlimited:   false,
-					MaxRequests: 2,
+					MaxRequests: 100,
 					Period:      time.Minute,
 				},
 				{
@@ -283,6 +300,14 @@ func TestLimiterAllow(t *testing.T) {
 					Per:         LimitPerIPAddress,
 					Unlimited:   false,
 					MaxRequests: 50,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 2,
 					Period:      time.Minute,
 				},
 			},
@@ -297,7 +322,7 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource",
 							Action:      "action",
-							Per:         LimitPerTotal,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
@@ -314,7 +339,7 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource",
 							Action:      "action",
-							Per:         LimitPerTotal,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
@@ -332,7 +357,7 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource",
 							Action:      "action",
-							Per:         LimitPerTotal,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
@@ -344,7 +369,7 @@ func TestLimiterAllow(t *testing.T) {
 		},
 		{
 			"ReachedCapacity",
-			4,
+			6,
 			[]*Limit{
 				{
 					Resource:    "resource1",
@@ -383,13 +408,37 @@ func TestLimiterAllow(t *testing.T) {
 					Action:      "action2",
 					Per:         LimitPerIPAddress,
 					Unlimited:   false,
-					MaxRequests: 1,
+					MaxRequests: 50,
 					Period:      time.Minute,
 				},
 				{
 					Resource:    "resource3",
 					Action:      "action3",
 					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 50,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource1",
+					Action:      "action1",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 25,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource2",
+					Action:      "action2",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 1,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource3",
+					Action:      "action3",
+					Per:         LimitPerAuthToken,
 					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
@@ -406,9 +455,9 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource1",
 							Action:      "action1",
-							Per:         LimitPerIPAddress,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
-							MaxRequests: 50,
+							MaxRequests: 25,
 							Period:      time.Minute,
 						},
 						used: 1,
@@ -423,7 +472,7 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource2",
 							Action:      "action2",
-							Per:         LimitPerIPAddress,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
@@ -451,9 +500,9 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource1",
 							Action:      "action1",
-							Per:         LimitPerIPAddress,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
-							MaxRequests: 50,
+							MaxRequests: 25,
 							Period:      time.Minute,
 						},
 						used: 2,
@@ -468,12 +517,208 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource2",
 							Action:      "action2",
-							Per:         LimitPerIPAddress,
+							Per:         LimitPerAuthToken,
 							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
 						used: 1,
+					},
+				},
+			},
+		},
+		{
+			"MultipleIPAddress",
+			10,
+			[]*Limit{
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerTotal,
+					Unlimited:   false,
+					MaxRequests: 3,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 2,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 1,
+					Period:      time.Minute,
+				},
+			},
+			[]Option{},
+			[]allowTestRequest{
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token1",
+					ip:            "ip1",
+					expectAllowed: true,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerAuthToken,
+							Unlimited:   false,
+							MaxRequests: 1,
+							Period:      time.Minute,
+						},
+						used: 1,
+					},
+				},
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token2",
+					ip:            "ip2",
+					expectAllowed: true,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerAuthToken,
+							Unlimited:   false,
+							MaxRequests: 1,
+							Period:      time.Minute,
+						},
+						used: 1,
+					},
+				},
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token3",
+					ip:            "ip3",
+					expectAllowed: true,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerTotal,
+							Unlimited:   false,
+							MaxRequests: 3,
+							Period:      time.Minute,
+						},
+						used: 3,
+					},
+				},
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token4",
+					ip:            "ip4",
+					expectAllowed: false,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerTotal,
+							Unlimited:   false,
+							MaxRequests: 3,
+							Period:      time.Minute,
+						},
+						used: 3,
+					},
+				},
+			},
+		},
+		{
+			"MultipleAuthTokens",
+			10,
+			[]*Limit{
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerTotal,
+					Unlimited:   false,
+					MaxRequests: 100,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 2,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerAuthToken,
+					Unlimited:   false,
+					MaxRequests: 1,
+					Period:      time.Minute,
+				},
+			},
+			[]Option{},
+			[]allowTestRequest{
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token1",
+					expectAllowed: true,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerAuthToken,
+							Unlimited:   false,
+							MaxRequests: 1,
+							Period:      time.Minute,
+						},
+						used: 1,
+					},
+				},
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token2",
+					expectAllowed: true,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerIPAddress,
+							Unlimited:   false,
+							MaxRequests: 2,
+							Period:      time.Minute,
+						},
+						used: 2,
+					},
+				},
+				{
+					resource:      "resource",
+					action:        "action",
+					authToken:     "token3",
+					expectAllowed: false,
+					expectErr:     nil,
+					expectQuota: &Quota{
+						limit: &Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         LimitPerIPAddress,
+							Unlimited:   false,
+							MaxRequests: 2,
+							Period:      time.Minute,
+						},
+						used: 2,
 					},
 				},
 			},
@@ -487,7 +732,7 @@ func TestLimiterAllow(t *testing.T) {
 			require.NotNil(t, l)
 
 			for _, r := range tc.reqs {
-				allowed, q, err := l.Allow(r.resource, r.action, r.ip)
+				allowed, q, err := l.Allow(r.resource, r.action, r.ip, r.authToken)
 				if r.expectErr != nil {
 					require.EqualError(t, err, r.expectErr.Error())
 					assert.Equal(t, r.expectAllowed, allowed)

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -176,6 +176,7 @@ func TestNewLimiter(t *testing.T) {
 type allowTestRequest struct {
 	resource string
 	action   string
+	ip       string
 
 	expectAllowed bool
 	expectErr     error
@@ -202,6 +203,14 @@ func TestLimiterAllow(t *testing.T) {
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 50,
+					Period:      time.Minute,
+				},
 			},
 			[]Option{},
 			[]allowTestRequest{
@@ -214,9 +223,9 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource",
 							Action:      "action",
-							Per:         LimitPerTotal,
+							Per:         LimitPerIPAddress,
 							Unlimited:   false,
-							MaxRequests: 100,
+							MaxRequests: 50,
 							Period:      time.Minute,
 						},
 						used: 1,
@@ -234,6 +243,14 @@ func TestLimiterAllow(t *testing.T) {
 					Per:         LimitPerTotal,
 					Unlimited:   false,
 					MaxRequests: 100,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 50,
 					Period:      time.Minute,
 				},
 			},
@@ -258,6 +275,14 @@ func TestLimiterAllow(t *testing.T) {
 					Per:         LimitPerTotal,
 					Unlimited:   false,
 					MaxRequests: 2,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 50,
 					Period:      time.Minute,
 				},
 			},
@@ -319,7 +344,7 @@ func TestLimiterAllow(t *testing.T) {
 		},
 		{
 			"ReachedCapacity",
-			2,
+			4,
 			[]*Limit{
 				{
 					Resource:    "resource1",
@@ -334,13 +359,37 @@ func TestLimiterAllow(t *testing.T) {
 					Action:      "action2",
 					Per:         LimitPerTotal,
 					Unlimited:   false,
-					MaxRequests: 1,
+					MaxRequests: 100,
 					Period:      time.Minute,
 				},
 				{
 					Resource:    "resource3",
 					Action:      "action3",
 					Per:         LimitPerTotal,
+					Unlimited:   false,
+					MaxRequests: 100,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource1",
+					Action:      "action1",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 50,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource2",
+					Action:      "action2",
+					Per:         LimitPerIPAddress,
+					Unlimited:   false,
+					MaxRequests: 1,
+					Period:      time.Minute,
+				},
+				{
+					Resource:    "resource3",
+					Action:      "action3",
+					Per:         LimitPerIPAddress,
 					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
@@ -357,9 +406,9 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource1",
 							Action:      "action1",
-							Per:         LimitPerTotal,
+							Per:         LimitPerIPAddress,
 							Unlimited:   false,
-							MaxRequests: 100,
+							MaxRequests: 50,
 							Period:      time.Minute,
 						},
 						used: 1,
@@ -374,7 +423,7 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource2",
 							Action:      "action2",
-							Per:         LimitPerTotal,
+							Per:         LimitPerIPAddress,
 							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
@@ -402,9 +451,9 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource1",
 							Action:      "action1",
-							Per:         LimitPerTotal,
+							Per:         LimitPerIPAddress,
 							Unlimited:   false,
-							MaxRequests: 100,
+							MaxRequests: 50,
 							Period:      time.Minute,
 						},
 						used: 2,
@@ -419,7 +468,7 @@ func TestLimiterAllow(t *testing.T) {
 						limit: &Limit{
 							Resource:    "resource2",
 							Action:      "action2",
-							Per:         LimitPerTotal,
+							Per:         LimitPerIPAddress,
 							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
@@ -438,7 +487,7 @@ func TestLimiterAllow(t *testing.T) {
 			require.NotNil(t, l)
 
 			for _, r := range tc.reqs {
-				allowed, q, err := l.Allow(r.resource, r.action)
+				allowed, q, err := l.Allow(r.resource, r.action, r.ip)
 				if r.expectErr != nil {
 					require.EqualError(t, err, r.expectErr.Error())
 					assert.Equal(t, r.expectAllowed, allowed)


### PR DESCRIPTION
This expands the rate lmiter to support limits per auth token and per IP address.
It also includes a CI job to run the benchmark tests for PRs and compare them against the base branch. The results of `benchstat` and then posted on the PR for review.