### PR TITLE
feat(limiter): Provide a time to retry when full

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,12 +3,22 @@
 
 package rate
 
-import "errors"
+import (
+	"errors"
+	"time"
+)
+
+// ErrLimiterFull is returned by Limiter.Allow when the limiter cannot store
+// any additional quotas.
+type ErrLimiterFull struct {
+	RetryIn time.Duration
+}
+
+func (l *ErrLimiterFull) Error() string {
+	return "limiter full"
+}
 
 var (
-	// ErrLimiterFull is returned by Limiter.Allow when the limiter cannot store
-	// any additional quotas.
-	ErrLimiterFull = errors.New("limiter full")
 	// ErrLimitNotFound is returned by Limiter.Allow when a limit could not be
 	// found for a given resource+action.
 	ErrLimitNotFound = errors.New("limit not found")

--- a/expirable_store_test.go
+++ b/expirable_store_test.go
@@ -124,7 +124,7 @@ func Test_storeCapacity(t *testing.T) {
 	}
 
 	_, err = s.fetch(fmt.Sprintf("id-%d", maxSize), limit)
-	require.ErrorIs(t, err, ErrLimiterFull)
+	require.EqualError(t, err, (&ErrLimiterFull{}).Error())
 }
 
 func Test_storeDeleteExpired(t *testing.T) {

--- a/limiter.go
+++ b/limiter.go
@@ -89,6 +89,9 @@ func NewLimiter(limits []*Limit, maxSize int, o ...Option) (*Limiter, error) {
 // A request is not allowed if:
 //   - Any of the associated quotas have been exhausted.
 //   - A new quota needs to be stored but there is no available space to store it.
+//     The error returned in this case will be a ErrLimiterFull with a provided
+//     RetryIn duration. Callers should use this time as an estimation of when
+//     the limiter should no longer be full.
 //   - There is no corresponding limit for the resource and action.
 func (l *Limiter) Allow(resource, action string) (allowed bool, quota *Quota, err error) {
 	l.mu.RLock()

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -388,7 +388,7 @@ func TestLimiterAllow(t *testing.T) {
 					resource:      "resource3",
 					action:        "action3",
 					expectAllowed: false,
-					expectErr:     ErrLimiterFull,
+					expectErr:     &ErrLimiterFull{RetryIn: (time.Minute / time.Duration(DefaultNumberBuckets-1))},
 					expectQuota:   nil,
 				},
 				// However, requests for quotas already in the store should
@@ -442,6 +442,11 @@ func TestLimiterAllow(t *testing.T) {
 				if r.expectErr != nil {
 					require.EqualError(t, err, r.expectErr.Error())
 					assert.Equal(t, r.expectAllowed, allowed)
+					if want, ok := r.expectErr.(*ErrLimiterFull); ok {
+						got, ok := err.(*ErrLimiterFull)
+						assert.True(t, ok, "did not get an ErrLimiterFull error")
+						assert.Equal(t, want.RetryIn, got.RetryIn)
+					}
 					continue
 				}
 


### PR DESCRIPTION
When a call to the Allow method on a Limiter results in an
ErrLimiterFull, the error now provides a time in which to retry. This
should be treated as an estimated amount of time until the Limiter has
deleted some expired quotas and should have capacity again.