### PR TITLE
Add methods for setting HTTP headers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Bench
         run: |
           make bench
+      - name: Lint
+        run: |
+          make lint
       - name: Gen diff
         run: |
           go mod tidy

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,50 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+linters:
+  disable-all: true
+  enable:
+    - staticcheck
+    - stylecheck
+    - misspell
+    - revive
+
+linters-settings:
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  include:
+    # Comments are important, these shouldn't be exlucded by default
+    - EXC0012
+    - EXC0013
+    - EXC0014
+    - EXC0015

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
+GO_PATH = $(shell go env GOPATH)
+
 .PHONY: all
 all: test
 
 .PHONY: tools
-tools:
+tools: golangci-lint
 	go install github.com/hashicorp/copywrite@v0.15.0
 	go install mvdan.cc/gofumpt@v0.3.1
 	go install golang.org/x/perf/cmd/benchstat@latest
+
+# golangci-lint recommends installing the binary directly, instead of using go get
+# See the note: https://golangci-lint.run/usage/install/#install-from-source
+.PHONY: golangci-lint
+golangci-lint:
+	$(eval GOLINT_INSTALLED := $(shell which golangci-lint))
+
+	if [ "$(GOLINT_INSTALLED)" = "" ]; then \
+		curl -sSfL \
+			https://raw.githubusercontent.com/golangci/golangci-lint/9a8a056e9fe49c0e9ed2287aedce1022c79a115b/install.sh | sh -s -- -b $(GO_PATH)/bin v1.52.2; \
+	fi;
 
 .PHONY: test
 test:
@@ -28,6 +41,10 @@ copywrite:
 .PHONY: fmt
 fmt:
 	gofumpt -w .
+
+.PHONY: lint
+lint:
+	golangci-lint run
 
 .PHONY: gen
 gen: copywrite fmt

--- a/errors.go
+++ b/errors.go
@@ -39,4 +39,10 @@ var (
 	// ErrStopped is returned by Limiter.Allow if the limiter has been stopped
 	// and cannot return a quota.
 	ErrStopped = errors.New("limiter stopped")
+	// ErrInvalidLimitPolicy is returned by NewLimiter when a valid limit policy
+	// could not be created from the provided limits.
+	ErrInvalidLimitPolicy = errors.New("invalid limit policy")
+	// ErrLimitPolicyNotFound is returned by a Limiter when a limit policy
+	// could not be found for a given resource+action.
+	ErrLimitPolicyNotFound = errors.New("limit policy not found")
 )

--- a/options.go
+++ b/options.go
@@ -9,6 +9,9 @@ const (
 
 	// DefaultPolicyHeader is the default HTTP header for reporting the rate limit policy.
 	DefaultPolicyHeader = "RateLimit-Policy"
+
+	// DefaultUsageHeader is the default HTTP header for reporting quota usage.
+	DefaultUsageHeader = "RateLimit"
 )
 
 // Option provides a way to pass optional arguments.
@@ -25,12 +28,14 @@ func getOpts(opt ...Option) options {
 type options struct {
 	withNumberBuckets int
 	withPolicyHeader  string
+	withUsageHeader   string
 }
 
 func getDefaultOptions() options {
 	return options{
 		withNumberBuckets: DefaultNumberBuckets,
 		withPolicyHeader:  DefaultPolicyHeader,
+		withUsageHeader:   DefaultUsageHeader,
 	}
 }
 
@@ -46,5 +51,13 @@ func WithNumberBuckets(n int) Option {
 func WithPolicyHeader(h string) Option {
 	return func(o *options) {
 		o.withPolicyHeader = h
+	}
+}
+
+// WithUsageHeader is used to set the header key used by the Limiter for
+// reporting quota usage.
+func WithUsageHeader(h string) Option {
+	return func(o *options) {
+		o.withUsageHeader = h
 	}
 }

--- a/options.go
+++ b/options.go
@@ -3,8 +3,13 @@
 
 package rate
 
-// DefaultNumberBuckets is the default number of buckets created for the quota store.
-const DefaultNumberBuckets = 4096
+const (
+	// DefaultNumberBuckets is the default number of buckets created for the quota store.
+	DefaultNumberBuckets = 4096
+
+	// DefaultPolicyHeader is the default HTTP header for reporting the rate limit policy.
+	DefaultPolicyHeader = "RateLimit-Policy"
+)
 
 // Option provides a way to pass optional arguments.
 type Option func(*options)
@@ -19,11 +24,13 @@ func getOpts(opt ...Option) options {
 
 type options struct {
 	withNumberBuckets int
+	withPolicyHeader  string
 }
 
 func getDefaultOptions() options {
 	return options{
 		withNumberBuckets: DefaultNumberBuckets,
+		withPolicyHeader:  DefaultPolicyHeader,
 	}
 }
 
@@ -31,5 +38,13 @@ func getDefaultOptions() options {
 func WithNumberBuckets(n int) Option {
 	return func(o *options) {
 		o.withNumberBuckets = n
+	}
+}
+
+// WithPolicyHeader is used to set the header key used by the Limiter for
+// reporting the limit policy.
+func WithPolicyHeader(h string) Option {
+	return func(o *options) {
+		o.withPolicyHeader = h
 	}
 }

--- a/options_test.go
+++ b/options_test.go
@@ -16,6 +16,7 @@ func TestGetOpts(t *testing.T) {
 		opts := getOpts()
 		testOpts := options{
 			withNumberBuckets: DefaultNumberBuckets,
+			withPolicyHeader:  DefaultPolicyHeader,
 		}
 		assert.Equal(t, opts, testOpts)
 	})
@@ -23,6 +24,16 @@ func TestGetOpts(t *testing.T) {
 		opts := getOpts(WithNumberBuckets(40))
 		testOpts := options{
 			withNumberBuckets: 40,
+			withPolicyHeader:  DefaultPolicyHeader,
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithPolicyHeader", func(t *testing.T) {
+		opts := getOpts(WithPolicyHeader("Limit-Policy"))
+		testOpts := options{
+			withNumberBuckets: DefaultNumberBuckets,
+			withPolicyHeader:  "Limit-Policy",
+			withUsageHeader:   DefaultUsageHeader,
 		}
 		assert.Equal(t, opts, testOpts)
 	})

--- a/options_test.go
+++ b/options_test.go
@@ -17,6 +17,7 @@ func TestGetOpts(t *testing.T) {
 		testOpts := options{
 			withNumberBuckets: DefaultNumberBuckets,
 			withPolicyHeader:  DefaultPolicyHeader,
+			withUsageHeader:   DefaultUsageHeader,
 		}
 		assert.Equal(t, opts, testOpts)
 	})
@@ -25,6 +26,7 @@ func TestGetOpts(t *testing.T) {
 		testOpts := options{
 			withNumberBuckets: 40,
 			withPolicyHeader:  DefaultPolicyHeader,
+			withUsageHeader:   DefaultUsageHeader,
 		}
 		assert.Equal(t, opts, testOpts)
 	})
@@ -34,6 +36,15 @@ func TestGetOpts(t *testing.T) {
 			withNumberBuckets: DefaultNumberBuckets,
 			withPolicyHeader:  "Limit-Policy",
 			withUsageHeader:   DefaultUsageHeader,
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithUsageHeader", func(t *testing.T) {
+		opts := getOpts(WithUsageHeader("Quota-Usage"))
+		testOpts := options{
+			withNumberBuckets: DefaultNumberBuckets,
+			withPolicyHeader:  DefaultPolicyHeader,
+			withUsageHeader:   "Quota-Usage",
 		}
 		assert.Equal(t, opts, testOpts)
 	})

--- a/policy.go
+++ b/policy.go
@@ -1,0 +1,95 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rate
+
+import (
+	"fmt"
+	"strings"
+)
+
+// limitPolicy is a collection of Limits for the same resource and action. A limitPolicy
+// should contain one Limit for each valid LimitPer.
+type limitPolicy struct {
+	resource string
+	action   string
+
+	m map[LimitPer]*Limit
+
+	policy string
+}
+
+var requiredLimitPer = []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken}
+
+func newLimitPolicy(resource, action string) *limitPolicy {
+	return &limitPolicy{
+		resource: resource,
+		action:   action,
+		m:        make(map[LimitPer]*Limit, 3),
+	}
+}
+
+// String returns a string representation of the LimitPolicy. This is formatted
+// for use as a rate limit policy HTTP header as outlined in:
+// https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/
+func (p *limitPolicy) String() string {
+	return p.policy
+}
+
+// limit returns the corresponding limit for the given LimitPer. If the policy
+// does not have a corresponding limit, ErrLimitNotFound is returned.
+func (p *limitPolicy) limit(per LimitPer) (*Limit, error) {
+	l, ok := p.m[per]
+	if !ok {
+		return nil, ErrLimitNotFound
+	}
+	return l, nil
+}
+
+func (p *limitPolicy) add(l *Limit) error {
+	switch {
+	case !l.IsValid():
+		return ErrInvalidLimit
+	case l.Resource != p.resource:
+		return fmt.Errorf("limit's resource does not match limit policy's: %w", ErrInvalidLimit)
+	case l.Action != p.action:
+		return fmt.Errorf("limit's action does not match limit policy's: %w", ErrInvalidLimit)
+	}
+
+	if _, ok := p.m[l.Per]; ok {
+		return ErrDuplicateLimit
+	}
+
+	p.m[l.Per] = l
+	p.buildStr()
+	return nil
+}
+
+func (p *limitPolicy) buildStr() {
+	s := make([]string, 0, 3)
+	for _, per := range requiredLimitPer {
+		l, ok := p.m[per]
+		if !ok || l.Unlimited {
+			continue
+		}
+		s = append(s, fmt.Sprintf("%d;w=%d;comment=%q", l.MaxRequests, uint64(l.Period.Seconds()), l.Per.String()))
+	}
+
+	p.policy = strings.Join(s, ", ")
+}
+
+func (p *limitPolicy) validate() error {
+	switch {
+	case p.resource == "":
+		return fmt.Errorf("missing resource: %w", ErrInvalidLimitPolicy)
+	case p.action == "":
+		return fmt.Errorf("missing action: %w", ErrInvalidLimitPolicy)
+	case len(p.m) != 3:
+		for _, per := range requiredLimitPer {
+			if _, ok := p.m[per]; !ok {
+				return fmt.Errorf("mising limit for %q: %w", per, ErrInvalidLimitPolicy)
+			}
+		}
+	}
+	return nil
+}

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,581 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rate
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitPolicy_add(t *testing.T) {
+	cases := []struct {
+		name        string
+		limitPolicy *limitPolicy
+		add         *Limit
+		expectErr   error
+	}{
+		{
+			"NoError",
+			newLimitPolicy("resource", "action"),
+			&Limit{
+				Resource:    "resource",
+				Action:      "action",
+				Per:         LimitPerTotal,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			nil,
+		},
+		{
+			"InvalidLimit",
+			newLimitPolicy("resource", "action"),
+			&Limit{
+				Resource:    "resource",
+				Action:      "action",
+				Per:         LimitPerTotal,
+				Unlimited:   true,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			ErrInvalidLimit,
+		},
+		{
+			"IncorrectResource",
+			newLimitPolicy("resource", "action"),
+			&Limit{
+				Resource:    "resource1",
+				Action:      "action",
+				Per:         LimitPerTotal,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			ErrInvalidLimit,
+		},
+		{
+			"IncorrectAction",
+			newLimitPolicy("resource", "action"),
+			&Limit{
+				Resource:    "resource",
+				Action:      "action1",
+				Per:         LimitPerTotal,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			ErrInvalidLimit,
+		},
+		{
+			"DuplicateLimit",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				lp.add(&Limit{
+					Resource:    "resource",
+					Action:      "action",
+					Per:         LimitPerTotal,
+					Unlimited:   false,
+					MaxRequests: 20,
+					Period:      time.Minute,
+				})
+				return lp
+			}(),
+			&Limit{
+				Resource:    "resource",
+				Action:      "action",
+				Per:         LimitPerTotal,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			ErrDuplicateLimit,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.limitPolicy.add(tc.add)
+			if tc.expectErr != nil {
+				require.ErrorIs(t, got, tc.expectErr)
+				return
+			}
+			require.NoError(t, got)
+		})
+	}
+}
+
+func TestLimitPolicyLimit(t *testing.T) {
+	cases := []struct {
+		name        string
+		limitPolicy *limitPolicy
+		per         LimitPer
+		expect      *Limit
+		expectErr   error
+	}{
+		{
+			"Total",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			LimitPerTotal,
+			&Limit{
+				Resource:    "resource",
+				Action:      "action",
+				Per:         LimitPerTotal,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			nil,
+		},
+		{
+			"LimitPerAuthToken",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			LimitPerAuthToken,
+			&Limit{
+				Resource:    "resource",
+				Action:      "action",
+				Per:         LimitPerAuthToken,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			nil,
+		},
+		{
+			"IPAddress",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			LimitPerIPAddress,
+			&Limit{
+				Resource:    "resource",
+				Action:      "action",
+				Per:         LimitPerIPAddress,
+				Unlimited:   false,
+				MaxRequests: 10,
+				Period:      time.Minute,
+			},
+			nil,
+		},
+		{
+			"Missing",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			LimitPerTotal,
+			nil,
+			ErrLimitNotFound,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := tc.limitPolicy.limit(tc.per)
+			if tc.expectErr != nil {
+				require.ErrorIs(t, err, tc.expectErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+func TestLimitPolicyString(t *testing.T) {
+	cases := []struct {
+		name        string
+		limitPolicy *limitPolicy
+		expect      string
+	}{
+		{
+			"Policy",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="total", 10;w=60;comment="ip-address", 10;w=60;comment="auth-token"`,
+		},
+		{
+			"UnlimitedTotal",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					var err error
+					switch per {
+					case LimitPerTotal:
+						err = lp.add(&Limit{
+							Resource:  "resource",
+							Action:    "action",
+							Per:       per,
+							Unlimited: true,
+						})
+					default:
+						err = lp.add(&Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         per,
+							Unlimited:   false,
+							MaxRequests: 10,
+							Period:      time.Minute,
+						})
+					}
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="ip-address", 10;w=60;comment="auth-token"`,
+		},
+		{
+			"UnlimitedIpAddress",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					var err error
+					switch per {
+					case LimitPerIPAddress:
+						err = lp.add(&Limit{
+							Resource:  "resource",
+							Action:    "action",
+							Per:       per,
+							Unlimited: true,
+						})
+					default:
+						err = lp.add(&Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         per,
+							Unlimited:   false,
+							MaxRequests: 10,
+							Period:      time.Minute,
+						})
+					}
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="total", 10;w=60;comment="auth-token"`,
+		},
+		{
+			"UnlimitedAuthToken",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					var err error
+					switch per {
+					case LimitPerAuthToken:
+						err = lp.add(&Limit{
+							Resource:  "resource",
+							Action:    "action",
+							Per:       per,
+							Unlimited: true,
+						})
+					default:
+						err = lp.add(&Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         per,
+							Unlimited:   false,
+							MaxRequests: 10,
+							Period:      time.Minute,
+						})
+					}
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="total", 10;w=60;comment="ip-address"`,
+		},
+		{
+			"UnlimitedIpAddressAuthToken",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					var err error
+					switch per {
+					case LimitPerIPAddress, LimitPerAuthToken:
+						err = lp.add(&Limit{
+							Resource:  "resource",
+							Action:    "action",
+							Per:       per,
+							Unlimited: true,
+						})
+					default:
+						err = lp.add(&Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         per,
+							Unlimited:   false,
+							MaxRequests: 10,
+							Period:      time.Minute,
+						})
+					}
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="total"`,
+		},
+		{
+			"UnlimitedIpAddressTotal",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					var err error
+					switch per {
+					case LimitPerIPAddress, LimitPerTotal:
+						err = lp.add(&Limit{
+							Resource:  "resource",
+							Action:    "action",
+							Per:       per,
+							Unlimited: true,
+						})
+					default:
+						err = lp.add(&Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         per,
+							Unlimited:   false,
+							MaxRequests: 10,
+							Period:      time.Minute,
+						})
+					}
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="auth-token"`,
+		},
+		{
+			"UnlimitedAuthTokenTotal",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					var err error
+					switch per {
+					case LimitPerAuthToken, LimitPerTotal:
+						err = lp.add(&Limit{
+							Resource:  "resource",
+							Action:    "action",
+							Per:       per,
+							Unlimited: true,
+						})
+					default:
+						err = lp.add(&Limit{
+							Resource:    "resource",
+							Action:      "action",
+							Per:         per,
+							Unlimited:   false,
+							MaxRequests: 10,
+							Period:      time.Minute,
+						})
+					}
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			`10;w=60;comment="ip-address"`,
+		},
+		{
+			"AllUnlimited",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:  "resource",
+						Action:    "action",
+						Per:       per,
+						Unlimited: true,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			``,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.limitPolicy.String()
+			assert.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+func TestLimitPolicy_validate(t *testing.T) {
+	cases := []struct {
+		name        string
+		limitPolicy *limitPolicy
+		expectErr   error
+	}{
+		{
+			"NoError",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			nil,
+		},
+		{
+			"MissingResource",
+			&limitPolicy{
+				resource: "",
+				action:   "action",
+			},
+			ErrInvalidLimitPolicy,
+		},
+		{
+			"MissingAction",
+			&limitPolicy{
+				resource: "resource",
+				action:   "",
+			},
+			ErrInvalidLimitPolicy,
+		},
+		{
+			"MissingPerTotal",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerIPAddress, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			ErrInvalidLimitPolicy,
+		},
+		{
+			"MissingPerIPAddress",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerAuthToken} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			ErrInvalidLimitPolicy,
+		},
+		{
+			"MissingPerAuthToken",
+			func() *limitPolicy {
+				lp := newLimitPolicy("resource", "action")
+				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress} {
+					err := lp.add(&Limit{
+						Resource:    "resource",
+						Action:      "action",
+						Per:         per,
+						Unlimited:   false,
+						MaxRequests: 10,
+						Period:      time.Minute,
+					})
+					require.NoError(t, err)
+				}
+				return lp
+			}(),
+			ErrInvalidLimitPolicy,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.limitPolicy.validate()
+			if tc.expectErr != nil {
+				require.ErrorIs(t, got, tc.expectErr)
+				return
+			}
+			require.NoError(t, got)
+		})
+	}
+}

--- a/quota.go
+++ b/quota.go
@@ -47,6 +47,15 @@ func (q *Quota) Remaining() uint64 {
 	return q.limit.MaxRequests - used
 }
 
+// MaxRequests returns the maximum number of requests that can be made for
+// this Quota.
+func (q *Quota) MaxRequests() uint64 {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	return q.limit.MaxRequests
+}
+
 // ResetsIn returns the amount of time before the quota will expire.
 func (q *Quota) ResetsIn() time.Duration {
 	q.mu.RLock()

--- a/quota_test.go
+++ b/quota_test.go
@@ -29,6 +29,7 @@ func TestQuota_reset(t *testing.T) {
 	q.reset(l)
 	assert.Equal(t, l, q.limit)
 	assert.Equal(t, uint64(0), q.used)
+	assert.Equal(t, uint64(10), q.MaxRequests())
 	q.used = 5
 
 	l2 := &Limit{
@@ -42,6 +43,7 @@ func TestQuota_reset(t *testing.T) {
 	q.reset(l2)
 	assert.Equal(t, l2, q.limit)
 	assert.Equal(t, uint64(0), q.used)
+	assert.Equal(t, uint64(50), q.MaxRequests())
 }
 
 func TestQuotaConsume(t *testing.T) {


### PR DESCRIPTION
This adds two methods for setting informational rate limit headers.

- SetPolicyHeader is used to report the current limit policy for the
  request. Clients can use this to understand that the limits are for
  the given request.
- SetUsageHeader is used to report the current usage. This allows
  clients to see how much quota remains so they can proactively limit
  their requests prior to consuming all of their quota.

The Limiter can be configured to the header keys. They default to
RateLimit-Policy and RateLimit.