### PR TITLE
feat: Add options for reporting quota storage metrics

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Bench New
         run: |
           # Run benchmarks without running any tests
-          go test -bench=. -count=10 -run=^# | tee new.txt
+          go test -timeout=120m -bench=. -count=5 -run=^# | tee new.txt
       - name: Bench Old
         run: |
           git checkout "${GITHUB_BASE_REF}"
           go mod download
           # Run benchmarks without running any tests
-          go test -bench=. -count=10 -run=^# | tee old.txt
+          go test -timeout=120m -bench=. -count=5 -run=^# | tee old.txt
           git checkout "${GITHUB_HEAD_REF}"
       - name: Benchstat
         run: |

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ cover-html:
 
 .PHONY: bench
 bench:
-	go test -v -bench=. -count=1 -run=^#
+	go test -timeout=120m -v -bench=. -count=1 -run=^#
 
 .PHONY: copywrite
 copywrite:

--- a/expirable_store_bench_test.go
+++ b/expirable_store_bench_test.go
@@ -1,0 +1,62 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rate
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// package variables to prevent allocations from getting optimized away
+var (
+	benchStore  *expirableStore
+	benchBucket bucket
+)
+
+// Benchmark_expirableStore is used to report on initial memory allocations
+// of the expirableStore when given different max sizes.
+func Benchmark_expirableStore(b *testing.B) {
+	cases := []int{
+		1,
+		2048,
+		32768,
+		262144,
+		524288,
+	}
+	for _, bc := range cases {
+		b.Run(strconv.Itoa(bc), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				var err error
+				benchStore, err = newExpirableStore(bc, time.Minute)
+				if err != nil {
+					b.Fatalf(err.Error())
+				}
+				benchStore.shutdown()
+			}
+		})
+	}
+}
+
+// Benchmark_bucket shows how much memory is allocated when creating a map
+// of buckets at the bucketSizeThreshold. This is mainly to detect if
+// something changes with how go allocates maps.
+func Benchmark_bucket(b *testing.B) {
+	cases := []int{
+		bucketSizeThreshold,
+		bucketSizeThreshold + 1,
+	}
+
+	for _, bc := range cases {
+		b.Run(strconv.Itoa(bc), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				benchBucket = bucket{
+					entries: make(map[string]*entry, bc),
+				}
+			}
+		})
+	}
+}

--- a/limiter.go
+++ b/limiter.go
@@ -51,6 +51,12 @@ type Limiter struct {
 //     header via SetPolicyHeader. This defaults to "RateLimit-Policy".
 //   - WithUsageHeader: Sets the HTTP Header key to use when setting the usage
 //     header via SetUsageHeader. This defaults to "RateLimit".
+//   - WithQuotaStorageCapacityMetric: Provides a gauge metric to report the
+//     total number of Quotas that can be stored by the Limiter. The default is
+//     to not report this metric.
+//   - WithQuotaStorageUsageMetric: Provides a gauge metric to report the
+//     current number of Quotas that are being stored by the Limiter. The
+//     default is to not report this metric.
 func NewLimiter(limits []*Limit, maxSize int, o ...Option) (*Limiter, error) {
 	const op = "rate.NewLimiter"
 

--- a/metric/metric.go
+++ b/metric/metric.go
@@ -1,0 +1,11 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+// Package metric provides interfaces for the types of metrics that the
+// rate.Limiter can use to aid in monitoring the limiter.
+package metric
+
+// Gauge is a metric that can increase and decrease over time.
+type Gauge interface {
+	Set(float64)
+}

--- a/options.go
+++ b/options.go
@@ -7,7 +7,7 @@ import "github.com/hashicorp/go-rate/metric"
 
 const (
 	// DefaultNumberBuckets is the default number of buckets created for the quota store.
-	DefaultNumberBuckets = 4096
+	DefaultNumberBuckets = 61
 
 	// DefaultPolicyHeader is the default HTTP header for reporting the rate limit policy.
 	DefaultPolicyHeader = "RateLimit-Policy"

--- a/options_test.go
+++ b/options_test.go
@@ -9,42 +9,106 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type testGauge struct {
+	v float64
+}
+
+func (t *testGauge) Set(f float64) {
+	t.v = f
+}
+
 func TestGetOpts(t *testing.T) {
 	t.Parallel()
 
 	t.Run("default", func(t *testing.T) {
 		opts := getOpts()
 		testOpts := options{
-			withNumberBuckets: DefaultNumberBuckets,
-			withPolicyHeader:  DefaultPolicyHeader,
-			withUsageHeader:   DefaultUsageHeader,
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    &nilGauge{},
 		}
 		assert.Equal(t, opts, testOpts)
 	})
 	t.Run("WithNumberBuckets", func(t *testing.T) {
 		opts := getOpts(WithNumberBuckets(40))
 		testOpts := options{
-			withNumberBuckets: 40,
-			withPolicyHeader:  DefaultPolicyHeader,
-			withUsageHeader:   DefaultUsageHeader,
+			withNumberBuckets:              40,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    &nilGauge{},
 		}
 		assert.Equal(t, opts, testOpts)
 	})
 	t.Run("WithPolicyHeader", func(t *testing.T) {
 		opts := getOpts(WithPolicyHeader("Limit-Policy"))
 		testOpts := options{
-			withNumberBuckets: DefaultNumberBuckets,
-			withPolicyHeader:  "Limit-Policy",
-			withUsageHeader:   DefaultUsageHeader,
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               "Limit-Policy",
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    &nilGauge{},
 		}
 		assert.Equal(t, opts, testOpts)
 	})
 	t.Run("WithUsageHeader", func(t *testing.T) {
 		opts := getOpts(WithUsageHeader("Quota-Usage"))
 		testOpts := options{
-			withNumberBuckets: DefaultNumberBuckets,
-			withPolicyHeader:  DefaultPolicyHeader,
-			withUsageHeader:   "Quota-Usage",
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                "Quota-Usage",
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    &nilGauge{},
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithQuotaStorageCapacityMetric", func(t *testing.T) {
+		g := &testGauge{}
+		g.Set(5.0)
+		opts := getOpts(WithQuotaStorageCapacityMetric(g))
+		testOpts := options{
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: g,
+			withQuotaStorageUsageMetric:    &nilGauge{},
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithQuotaStorageCapacityMetricNil", func(t *testing.T) {
+		opts := getOpts(WithQuotaStorageCapacityMetric(nil))
+		testOpts := options{
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    &nilGauge{},
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithQuotaStorageUsageMetric", func(t *testing.T) {
+		g := &testGauge{}
+		g.Set(5.0)
+		opts := getOpts(WithQuotaStorageUsageMetric(g))
+		testOpts := options{
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    g,
+		}
+		assert.Equal(t, opts, testOpts)
+	})
+	t.Run("WithQuotaStorageUsageMetricNil", func(t *testing.T) {
+		opts := getOpts(WithQuotaStorageUsageMetric(nil))
+		testOpts := options{
+			withNumberBuckets:              DefaultNumberBuckets,
+			withPolicyHeader:               DefaultPolicyHeader,
+			withUsageHeader:                DefaultUsageHeader,
+			withQuotaStorageCapacityMetric: &nilGauge{},
+			withQuotaStorageUsageMetric:    &nilGauge{},
 		}
 		assert.Equal(t, opts, testOpts)
 	})

--- a/quota_bench_test.go
+++ b/quota_bench_test.go
@@ -1,0 +1,18 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rate
+
+import (
+	"testing"
+)
+
+// package variables to prevent allocations from getting optimized away
+var benchQuota *Quota
+
+func BenchmarkQuota(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		benchQuota = &Quota{}
+	}
+}


### PR DESCRIPTION
This allows the Limiter to be provided two gauges that it will used to 
report metrics on the quota storage. It proivdes a metrics for the total 
capacity of the underlying quota storage, and the number of quotas 
currently being stored.

---

This also includes a commit to address the default memory consumption of
the limiter.