### PR TITLE
feat(limiter): Handle limits that are set as unlimited

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -54,13 +54,13 @@ jobs:
       - name: Bench New
         run: |
           # Run benchmarks without running any tests
-          go test -timeout=120m -bench=. -count=5 -run=^# | tee new.txt
+          go test -timeout=120m -bench=. -count=6 -run=^# | tee new.txt
       - name: Bench Old
         run: |
           git checkout "${GITHUB_BASE_REF}"
           go mod download
           # Run benchmarks without running any tests
-          go test -timeout=120m -bench=. -count=5 -run=^# | tee old.txt
+          go test -timeout=120m -bench=. -count=6 -run=^# | tee old.txt
           git checkout "${GITHUB_HEAD_REF}"
       - name: Benchstat
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,7 +44,6 @@ issues:
   max-same-issues: 0
   include:
     # Comments are important, these shouldn't be exlucded by default
-    - EXC0012
     - EXC0013
     - EXC0014
     - EXC0015

--- a/errors.go
+++ b/errors.go
@@ -28,6 +28,9 @@ var (
 	ErrEmptyLimits = errors.New("limits must not be empty")
 	// ErrInvalidLimit is returned by NewLimiter when a limit is not valid.
 	ErrInvalidLimit = errors.New("invalid limit")
+	// ErrInvalidLimitPer is returned by Limit.validate when a Limit has a invalid
+	// LimitPer.
+	ErrInvalidLimitPer = errors.New(`invalid limit per, must be one of "total", "ip-address", or "auth-token"`)
 	// ErrDuplicateLimit is returned by NewLimiter when it is provided duplicate
 	// limits.
 	ErrDuplicateLimit = errors.New("duplicate limit")

--- a/errors.go
+++ b/errors.go
@@ -48,4 +48,7 @@ var (
 	// ErrLimitPolicyNotFound is returned by a Limiter when a limit policy
 	// could not be found for a given resource+action.
 	ErrLimitPolicyNotFound = errors.New("limit policy not found")
+	// ErrUnlimited is returned by NewLimiter when all of the provided Limits
+	// are Unlimited.
+	ErrUnlimited = errors.New("all limits are Unlimited")
 )

--- a/expirable_store.go
+++ b/expirable_store.go
@@ -128,7 +128,7 @@ func (s *expirableStore) deleteExpired() {
 }
 
 // TODO: document this
-func (s *expirableStore) fetch(id string, limit *Limit) (*Quota, error) {
+func (s *expirableStore) fetch(id string, limit *Limited) (*Quota, error) {
 	select {
 	case <-s.ctx.Done():
 		return nil, ErrStopped

--- a/expirable_store_test.go
+++ b/expirable_store_test.go
@@ -109,11 +109,10 @@ func Test_storeCapacity(t *testing.T) {
 	s, err := newExpirableStore(maxSize, time.Minute)
 	require.NoError(t, err)
 
-	limit := &Limit{
+	limit := &Limited{
 		Resource:    "resource",
 		Action:      "action",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      time.Minute,
 	}
@@ -134,20 +133,18 @@ func Test_storeDeleteExpired(t *testing.T) {
 	s, err := newExpirableStore(20, maxPeriod, WithNumberBuckets(numberBuckets))
 	require.NoError(t, err)
 
-	short := &Limit{
+	short := &Limited{
 		Resource:    "resource",
 		Action:      "short",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      maxPeriod / time.Duration(numberBuckets),
 	}
 
-	long := &Limit{
+	long := &Limited{
 		Resource:    "resource",
 		Action:      "long",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      maxPeriod,
 	}
@@ -186,11 +183,10 @@ func Test_ResetBucketSize(t *testing.T) {
 	s, err := newExpirableStore(20, maxPeriod, WithNumberBuckets(numberBuckets))
 	require.NoError(t, err)
 
-	limit := &Limit{
+	limit := &Limited{
 		Resource:    "resource",
 		Action:      "action",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      maxPeriod,
 	}
@@ -238,11 +234,10 @@ func Test_storeFetchExpired(t *testing.T) {
 	s, err := newExpirableStore(20, maxPeriod, WithNumberBuckets(numberBuckets))
 	require.NoError(t, err)
 
-	limit := &Limit{
+	limit := &Limited{
 		Resource:    "resource",
 		Action:      "short",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      time.Millisecond,
 	}

--- a/limiter.go
+++ b/limiter.go
@@ -125,12 +125,12 @@ func (l *Limiter) SetPolicyHeader(resource, action string, header http.Header) e
 	if !ok {
 		return ErrLimitPolicyNotFound
 	}
-	p := pol.String()
+	p := pol.httpHeaderValue()
 	if p == "" {
 		return nil
 	}
 
-	header.Set(l.policyHeader, pol.String())
+	header.Set(l.policyHeader, pol.httpHeaderValue())
 	return nil
 }
 

--- a/limiter_bench_test.go
+++ b/limiter_bench_test.go
@@ -12,7 +12,7 @@ import (
 func BenchmarkAllow(b *testing.B) {
 	numResources := 128
 	resources := make([]string, 128)
-	limits := make([]*Limit, 0, 3*numResources)
+	limits := make([]Limit, 0, 3*numResources)
 	action := "action"
 
 	for i := 0; i < numResources; i++ {
@@ -20,27 +20,24 @@ func BenchmarkAllow(b *testing.B) {
 		resources[i] = res
 		limits = append(
 			limits,
-			&Limit{
+			&Limited{
 				Resource:    res,
 				Action:      action,
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 100,
 				Period:      time.Minute,
 			},
-			&Limit{
+			&Limited{
 				Resource:    res,
 				Action:      action,
 				Per:         LimitPerIPAddress,
-				Unlimited:   false,
 				MaxRequests: 100,
 				Period:      time.Minute,
 			},
-			&Limit{
+			&Limited{
 				Resource:    res,
 				Action:      action,
 				Per:         LimitPerAuthToken,
-				Unlimited:   false,
 				MaxRequests: 100,
 				Period:      time.Minute,
 			},

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -17,7 +17,7 @@ func TestNewLimiter(t *testing.T) {
 	cases := []struct {
 		name           string
 		maxSize        int
-		limits         []*Limit
+		limits         []Limit
 		options        []Option
 		expectErr      error
 		expectPolicies map[string]*limitPolicy
@@ -25,28 +25,25 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"ValidPolicy",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -57,28 +54,25 @@ func TestNewLimiter(t *testing.T) {
 				"resource:action": {
 					resource: "resource",
 					action:   "action",
-					m: map[LimitPer]*Limit{
-						LimitPerTotal: {
+					m: map[LimitPer]Limit{
+						LimitPerTotal: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerTotal,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
-						LimitPerIPAddress: {
+						LimitPerIPAddress: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerIPAddress,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
-						LimitPerAuthToken: {
+						LimitPerAuthToken: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
@@ -90,52 +84,46 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"MultiplePolicies",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource1",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource1",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource1",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -146,28 +134,25 @@ func TestNewLimiter(t *testing.T) {
 				"resource1:action": {
 					resource: "resource1",
 					action:   "action",
-					m: map[LimitPer]*Limit{
-						LimitPerTotal: {
+					m: map[LimitPer]Limit{
+						LimitPerTotal: &Limited{
 							Resource:    "resource1",
 							Action:      "action",
 							Per:         LimitPerTotal,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
-						LimitPerIPAddress: {
+						LimitPerIPAddress: &Limited{
 							Resource:    "resource1",
 							Action:      "action",
 							Per:         LimitPerIPAddress,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
-						LimitPerAuthToken: {
+						LimitPerAuthToken: &Limited{
 							Resource:    "resource1",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
@@ -177,28 +162,25 @@ func TestNewLimiter(t *testing.T) {
 				"resource2:action": {
 					resource: "resource2",
 					action:   "action",
-					m: map[LimitPer]*Limit{
-						LimitPerTotal: {
+					m: map[LimitPer]Limit{
+						LimitPerTotal: &Limited{
 							Resource:    "resource2",
 							Action:      "action",
 							Per:         LimitPerTotal,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
-						LimitPerIPAddress: {
+						LimitPerIPAddress: &Limited{
 							Resource:    "resource2",
 							Action:      "action",
 							Per:         LimitPerIPAddress,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
-						LimitPerAuthToken: {
+						LimitPerAuthToken: &Limited{
 							Resource:    "resource2",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 100,
 							Period:      time.Minute,
 						},
@@ -210,12 +192,11 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"OneLimit",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -227,20 +208,18 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"MultipleLimits",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "res2",
 					Action:      "action2",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Second,
 				},
-				{
+				&Limited{
 					Resource:    "res1",
 					Action:      "action1",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -252,20 +231,18 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"DuplicateLimits",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Second,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 10,
 					Period:      time.Minute,
 				},
@@ -277,13 +254,12 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"InvalidLimit",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   true,
-					MaxRequests: 100,
+					MaxRequests: 0,
 					Period:      time.Minute,
 				},
 			},
@@ -294,7 +270,7 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"NoLimits",
 			10,
-			[]*Limit{},
+			[]Limit{},
 			[]Option{},
 			ErrEmptyLimits,
 			nil,
@@ -302,28 +278,25 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"InvalidMaxSize",
 			0,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -335,28 +308,25 @@ func TestNewLimiter(t *testing.T) {
 		{
 			"InvalidNumberBuckets",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -397,35 +367,32 @@ func TestLimiterAllow(t *testing.T) {
 	cases := []struct {
 		name    string
 		maxSize int
-		limits  []*Limit
+		limits  []Limit
 		options []Option
 		reqs    []allowTestRequest
 	}{
 		{
 			"OneRequest",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 25,
 					Period:      time.Minute,
 				},
@@ -438,11 +405,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 25,
 							Period:      time.Minute,
 						},
@@ -454,28 +420,25 @@ func TestLimiterAllow(t *testing.T) {
 		{
 			"MissingLimitPolicy",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 25,
 					Period:      time.Minute,
 				},
@@ -494,28 +457,25 @@ func TestLimiterAllow(t *testing.T) {
 		{
 			"ConsumeQuota",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
 				},
@@ -528,11 +488,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
 						},
@@ -545,11 +504,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
 						},
@@ -563,11 +521,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: false,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
 						},
@@ -579,76 +536,67 @@ func TestLimiterAllow(t *testing.T) {
 		{
 			"ReachedCapacity",
 			6,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource1",
 					Action:      "action1",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action2",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource3",
 					Action:      "action3",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource1",
 					Action:      "action1",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action2",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource3",
 					Action:      "action3",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource1",
 					Action:      "action1",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 25,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action2",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 1,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource3",
 					Action:      "action3",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
 				},
@@ -661,11 +609,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource1",
 							Action:      "action1",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 25,
 							Period:      time.Minute,
 						},
@@ -678,11 +625,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource2",
 							Action:      "action2",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -706,11 +652,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource1",
 							Action:      "action1",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 25,
 							Period:      time.Minute,
 						},
@@ -723,11 +668,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: false,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource2",
 							Action:      "action2",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -739,28 +683,25 @@ func TestLimiterAllow(t *testing.T) {
 		{
 			"MultipleIPAddress",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 3,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 1,
 					Period:      time.Minute,
 				},
@@ -775,11 +716,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -794,11 +734,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -813,11 +752,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerTotal,
-							Unlimited:   false,
 							MaxRequests: 3,
 							Period:      time.Minute,
 						},
@@ -832,11 +770,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: false,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerTotal,
-							Unlimited:   false,
 							MaxRequests: 3,
 							Period:      time.Minute,
 						},
@@ -848,28 +785,25 @@ func TestLimiterAllow(t *testing.T) {
 		{
 			"MultipleAuthTokens",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 1,
 					Period:      time.Minute,
 				},
@@ -883,11 +817,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -901,11 +834,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerIPAddress,
-							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
 						},
@@ -919,11 +851,10 @@ func TestLimiterAllow(t *testing.T) {
 					expectAllowed: false,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerIPAddress,
-							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
 						},
@@ -955,9 +886,17 @@ func TestLimiterAllow(t *testing.T) {
 
 				require.NoError(t, err)
 				assert.Equal(t, r.expectAllowed, allowed)
-				assert.Equal(t, r.expectQuota.limit, q.limit)
-				assert.Equal(t, r.expectQuota.used, q.used)
-				assert.Equal(t, r.expectQuota.Remaining(), q.Remaining())
+				if r.expectQuota == nil {
+					assert.Nil(t, q)
+				} else {
+					require.NotNil(t, r.expectQuota)
+					require.NotNil(t, q)
+					require.NotNil(t, r.expectQuota.limit)
+					require.NotNil(t, q.limit)
+					assert.Equal(t, r.expectQuota.limit, q.limit)
+					assert.Equal(t, r.expectQuota.used, q.used)
+					assert.Equal(t, r.expectQuota.Remaining(), q.Remaining())
+				}
 			}
 		})
 	}
@@ -968,7 +907,7 @@ func TestSetPolicyHeader(t *testing.T) {
 	cases := []struct {
 		name              string
 		maxSize           int
-		limits            []*Limit
+		limits            []Limit
 		options           []Option
 		resource          string
 		action            string
@@ -979,28 +918,25 @@ func TestSetPolicyHeader(t *testing.T) {
 		{
 			"ValidPolicy",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -1015,28 +951,25 @@ func TestSetPolicyHeader(t *testing.T) {
 		{
 			"ValidPolicyAlternateHeader",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -1051,28 +984,25 @@ func TestSetPolicyHeader(t *testing.T) {
 		{
 			"PolicyNotFound",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -1087,46 +1017,40 @@ func TestSetPolicyHeader(t *testing.T) {
 		{
 			"Unlimited",
 			10,
-			[]*Limit{
-				{
-					Resource:  "resource",
-					Action:    "action",
-					Per:       LimitPerTotal,
-					Unlimited: true,
+			[]Limit{
+				&Unlimited{
+					Resource: "resource",
+					Action:   "action",
+					Per:      LimitPerTotal,
 				},
-				{
-					Resource:  "resource",
-					Action:    "action",
-					Per:       LimitPerIPAddress,
-					Unlimited: true,
+				&Unlimited{
+					Resource: "resource",
+					Action:   "action",
+					Per:      LimitPerIPAddress,
 				},
-				{
-					Resource:  "resource",
-					Action:    "action",
-					Per:       LimitPerAuthToken,
-					Unlimited: true,
+				&Unlimited{
+					Resource: "resource",
+					Action:   "action",
+					Per:      LimitPerAuthToken,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource2",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
@@ -1172,11 +1096,10 @@ func TestSetUsageHeader(t *testing.T) {
 			"ValidPolicy",
 			[]Option{},
 			&Quota{
-				limit: &Limit{
+				limit: &Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
@@ -1191,11 +1114,10 @@ func TestSetUsageHeader(t *testing.T) {
 			"ValidPolicyAlternateHeader",
 			[]Option{WithUsageHeader("Usage-Header")},
 			&Quota{
-				limit: &Limit{
+				limit: &Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
@@ -1219,28 +1141,25 @@ func TestSetUsageHeader(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			l, err := NewLimiter(
-				[]*Limit{
-					{
+				[]Limit{
+					&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         LimitPerTotal,
-						Unlimited:   false,
 						MaxRequests: 100,
 						Period:      time.Minute,
 					},
-					{
+					&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         LimitPerIPAddress,
-						Unlimited:   false,
 						MaxRequests: 100,
 						Period:      time.Minute,
 					},
-					{
+					&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         LimitPerAuthToken,
-						Unlimited:   false,
 						MaxRequests: 100,
 						Period:      time.Minute,
 					},
@@ -1262,34 +1181,31 @@ func TestLimiterQuotaCapacityMetric(t *testing.T) {
 	cases := []struct {
 		name    string
 		maxSize int
-		limits  []*Limit
+		limits  []Limit
 		gauge   *testGauge
 	}{
 		{
 			"NewGauge",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 25,
 					Period:      time.Minute,
 				},
@@ -1299,28 +1215,25 @@ func TestLimiterQuotaCapacityMetric(t *testing.T) {
 		{
 			"ExistingGauge",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 25,
 					Period:      time.Minute,
 				},
@@ -1344,7 +1257,7 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 	cases := []struct {
 		name        string
 		maxSize     int
-		limits      []*Limit
+		limits      []Limit
 		gauge       *testGauge
 		reqs        []allowTestRequest
 		expectUsage float64
@@ -1352,28 +1265,25 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 		{
 			"OneRequest",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 50,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 25,
 					Period:      time.Minute,
 				},
@@ -1386,11 +1296,10 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 25,
 							Period:      time.Minute,
 						},
@@ -1403,28 +1312,25 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 		{
 			"MultipleIPAddress",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 3,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 1,
 					Period:      time.Minute,
 				},
@@ -1439,11 +1345,10 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -1458,11 +1363,10 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -1477,11 +1381,10 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerTotal,
-							Unlimited:   false,
 							MaxRequests: 3,
 							Period:      time.Minute,
 						},
@@ -1494,28 +1397,25 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 		{
 			"MultipleAuthTokens",
 			10,
-			[]*Limit{
-				{
+			[]Limit{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 100,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerIPAddress,
-					Unlimited:   false,
 					MaxRequests: 2,
 					Period:      time.Minute,
 				},
-				{
+				&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerAuthToken,
-					Unlimited:   false,
 					MaxRequests: 1,
 					Period:      time.Minute,
 				},
@@ -1529,11 +1429,10 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerAuthToken,
-							Unlimited:   false,
 							MaxRequests: 1,
 							Period:      time.Minute,
 						},
@@ -1547,11 +1446,10 @@ func TestLimiterQuotaUsageMetric(t *testing.T) {
 					expectAllowed: true,
 					expectErr:     nil,
 					expectQuota: &Quota{
-						limit: &Limit{
+						limit: &Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         LimitPerIPAddress,
-							Unlimited:   false,
 							MaxRequests: 2,
 							Period:      time.Minute,
 						},

--- a/noplimiter.go
+++ b/noplimiter.go
@@ -1,0 +1,39 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rate
+
+import "net/http"
+
+type nopLimiter struct{}
+
+// SetPolicyHeader is a noop.
+func (*nopLimiter) SetPolicyHeader(_, _ string, _ http.Header) error { return nil }
+
+// SetUsageHeader is a noop.
+func (*nopLimiter) SetUsageHeader(_ *Quota, _ http.Header) { return }
+
+// Allow will always allow.
+func (*nopLimiter) Allow(_, _, _, _ string) (bool, *Quota, error) {
+	return true, nil, nil
+}
+
+// Shutdown is a noop.
+func (*nopLimiter) Shutdown() error { return nil }
+
+// NopLimiter can be used in the place of a Limiter when no limits need to be
+// enforced, but a Limiter is expected.
+var NopLimiter *nopLimiter
+
+type limiter interface {
+	SetPolicyHeader(string, string, http.Header) error
+	SetUsageHeader(*Quota, http.Header)
+	Allow(string, string, string, string) (bool, *Quota, error)
+	Shutdown() error
+}
+
+// Ensure that both NopLimiter and Limiter match the same interface.
+var (
+	_ limiter = NopLimiter
+	_ limiter = (*Limiter)(nil)
+)

--- a/noplimiter_test.go
+++ b/noplimiter_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package rate_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/hashicorp/go-rate"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnlimiterAllow(t *testing.T) {
+	cases := []struct {
+		name      string
+		res       string
+		action    string
+		ip        string
+		authtoken string
+	}{
+		{
+			"empty",
+			"",
+			"",
+			"",
+			"",
+		},
+		{
+			"notEmpty",
+			"res",
+			"action",
+			"127.0.0.1",
+			"auth-token",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			a, q, err := rate.NopLimiter.Allow(tc.res, tc.action, tc.ip, tc.authtoken)
+			require.NoError(t, err)
+			assert.Nil(t, q)
+			assert.True(t, a)
+		})
+	}
+}
+
+func TestUnlimitedSetPolicyHeader(t *testing.T) {
+	cases := []struct {
+		name   string
+		res    string
+		action string
+	}{
+		{
+			"empty",
+			"",
+			"",
+		},
+		{
+			"notEmpty",
+			"res",
+			"action",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := make(http.Header)
+			err := rate.NopLimiter.SetPolicyHeader(tc.res, tc.action, h)
+			require.NoError(t, err)
+			assert.Empty(t, h)
+		})
+	}
+}
+
+func TestUnlimitedSetUsageHeader(t *testing.T) {
+	cases := []struct {
+		name string
+		q    *rate.Quota
+	}{
+		{
+			"nil",
+			nil,
+		},
+		{
+			"notNil",
+			&rate.Quota{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := make(http.Header)
+			rate.NopLimiter.SetUsageHeader(tc.q, h)
+			assert.Empty(t, h)
+		})
+	}
+}
+
+func TestUnlimitedShutdown(t *testing.T) {
+	err := rate.NopLimiter.Shutdown()
+	assert.NoError(t, err)
+}

--- a/policy.go
+++ b/policy.go
@@ -29,10 +29,10 @@ func newLimitPolicy(resource, action string) *limitPolicy {
 	}
 }
 
-// String returns a string representation of the LimitPolicy. This is formatted
-// for use as a rate limit policy HTTP header as outlined in:
+// httpHeaderValue returns a string representation of the LimitPolicy. This is
+// formatted for use as a rate limit policy HTTP header as outlined in:
 // https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/
-func (p *limitPolicy) String() string {
+func (p *limitPolicy) httpHeaderValue() string {
 	return p.policy
 }
 

--- a/policy_test.go
+++ b/policy_test.go
@@ -15,17 +15,16 @@ func TestLimitPolicy_add(t *testing.T) {
 	cases := []struct {
 		name        string
 		limitPolicy *limitPolicy
-		add         *Limit
+		add         Limit
 		expectErr   error
 	}{
 		{
 			"NoError",
 			newLimitPolicy("resource", "action"),
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -34,12 +33,11 @@ func TestLimitPolicy_add(t *testing.T) {
 		{
 			"InvalidLimit",
 			newLimitPolicy("resource", "action"),
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   true,
-				MaxRequests: 10,
+				MaxRequests: 0,
 				Period:      time.Minute,
 			},
 			ErrInvalidLimit,
@@ -47,11 +45,10 @@ func TestLimitPolicy_add(t *testing.T) {
 		{
 			"IncorrectResource",
 			newLimitPolicy("resource", "action"),
-			&Limit{
+			&Limited{
 				Resource:    "resource1",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -60,11 +57,10 @@ func TestLimitPolicy_add(t *testing.T) {
 		{
 			"IncorrectAction",
 			newLimitPolicy("resource", "action"),
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action1",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -74,21 +70,19 @@ func TestLimitPolicy_add(t *testing.T) {
 			"DuplicateLimit",
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
-				lp.add(&Limit{
+				lp.add(&Limited{
 					Resource:    "resource",
 					Action:      "action",
 					Per:         LimitPerTotal,
-					Unlimited:   false,
 					MaxRequests: 20,
 					Period:      time.Minute,
 				})
 				return lp
 			}(),
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -113,7 +107,7 @@ func TestLimitPolicyLimit(t *testing.T) {
 		name        string
 		limitPolicy *limitPolicy
 		per         LimitPer
-		expect      *Limit
+		expect      Limit
 		expectErr   error
 	}{
 		{
@@ -121,11 +115,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -134,11 +127,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 				return lp
 			}(),
 			LimitPerTotal,
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -149,11 +141,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -162,11 +153,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 				return lp
 			}(),
 			LimitPerAuthToken,
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerAuthToken,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -177,11 +167,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -190,11 +179,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 				return lp
 			}(),
 			LimitPerIPAddress,
-			&Limit{
+			&Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerIPAddress,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      time.Minute,
 			},
@@ -205,11 +193,10 @@ func TestLimitPolicyLimit(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -247,11 +234,10 @@ func TestLimitPolicyString(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -269,18 +255,16 @@ func TestLimitPolicyString(t *testing.T) {
 					var err error
 					switch per {
 					case LimitPerTotal:
-						err = lp.add(&Limit{
-							Resource:  "resource",
-							Action:    "action",
-							Per:       per,
-							Unlimited: true,
+						err = lp.add(&Unlimited{
+							Resource: "resource",
+							Action:   "action",
+							Per:      per,
 						})
 					default:
-						err = lp.add(&Limit{
+						err = lp.add(&Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         per,
-							Unlimited:   false,
 							MaxRequests: 10,
 							Period:      time.Minute,
 						})
@@ -299,18 +283,16 @@ func TestLimitPolicyString(t *testing.T) {
 					var err error
 					switch per {
 					case LimitPerIPAddress:
-						err = lp.add(&Limit{
-							Resource:  "resource",
-							Action:    "action",
-							Per:       per,
-							Unlimited: true,
+						err = lp.add(&Unlimited{
+							Resource: "resource",
+							Action:   "action",
+							Per:      per,
 						})
 					default:
-						err = lp.add(&Limit{
+						err = lp.add(&Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         per,
-							Unlimited:   false,
 							MaxRequests: 10,
 							Period:      time.Minute,
 						})
@@ -329,18 +311,16 @@ func TestLimitPolicyString(t *testing.T) {
 					var err error
 					switch per {
 					case LimitPerAuthToken:
-						err = lp.add(&Limit{
-							Resource:  "resource",
-							Action:    "action",
-							Per:       per,
-							Unlimited: true,
+						err = lp.add(&Unlimited{
+							Resource: "resource",
+							Action:   "action",
+							Per:      per,
 						})
 					default:
-						err = lp.add(&Limit{
+						err = lp.add(&Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         per,
-							Unlimited:   false,
 							MaxRequests: 10,
 							Period:      time.Minute,
 						})
@@ -359,18 +339,16 @@ func TestLimitPolicyString(t *testing.T) {
 					var err error
 					switch per {
 					case LimitPerIPAddress, LimitPerAuthToken:
-						err = lp.add(&Limit{
-							Resource:  "resource",
-							Action:    "action",
-							Per:       per,
-							Unlimited: true,
+						err = lp.add(&Unlimited{
+							Resource: "resource",
+							Action:   "action",
+							Per:      per,
 						})
 					default:
-						err = lp.add(&Limit{
+						err = lp.add(&Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         per,
-							Unlimited:   false,
 							MaxRequests: 10,
 							Period:      time.Minute,
 						})
@@ -389,18 +367,16 @@ func TestLimitPolicyString(t *testing.T) {
 					var err error
 					switch per {
 					case LimitPerIPAddress, LimitPerTotal:
-						err = lp.add(&Limit{
-							Resource:  "resource",
-							Action:    "action",
-							Per:       per,
-							Unlimited: true,
+						err = lp.add(&Unlimited{
+							Resource: "resource",
+							Action:   "action",
+							Per:      per,
 						})
 					default:
-						err = lp.add(&Limit{
+						err = lp.add(&Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         per,
-							Unlimited:   false,
 							MaxRequests: 10,
 							Period:      time.Minute,
 						})
@@ -419,18 +395,16 @@ func TestLimitPolicyString(t *testing.T) {
 					var err error
 					switch per {
 					case LimitPerAuthToken, LimitPerTotal:
-						err = lp.add(&Limit{
-							Resource:  "resource",
-							Action:    "action",
-							Per:       per,
-							Unlimited: true,
+						err = lp.add(&Unlimited{
+							Resource: "resource",
+							Action:   "action",
+							Per:      per,
 						})
 					default:
-						err = lp.add(&Limit{
+						err = lp.add(&Limited{
 							Resource:    "resource",
 							Action:      "action",
 							Per:         per,
-							Unlimited:   false,
 							MaxRequests: 10,
 							Period:      time.Minute,
 						})
@@ -446,11 +420,10 @@ func TestLimitPolicyString(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
-						Resource:  "resource",
-						Action:    "action",
-						Per:       per,
-						Unlimited: true,
+					err := lp.add(&Unlimited{
+						Resource: "resource",
+						Action:   "action",
+						Per:      per,
 					})
 					require.NoError(t, err)
 				}
@@ -479,11 +452,10 @@ func TestLimitPolicy_validate(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -514,11 +486,10 @@ func TestLimitPolicy_validate(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerIPAddress, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -533,11 +504,10 @@ func TestLimitPolicy_validate(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerAuthToken} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})
@@ -552,11 +522,10 @@ func TestLimitPolicy_validate(t *testing.T) {
 			func() *limitPolicy {
 				lp := newLimitPolicy("resource", "action")
 				for _, per := range []LimitPer{LimitPerTotal, LimitPerIPAddress} {
-					err := lp.add(&Limit{
+					err := lp.add(&Limited{
 						Resource:    "resource",
 						Action:      "action",
 						Per:         per,
-						Unlimited:   false,
 						MaxRequests: 10,
 						Period:      time.Minute,
 					})

--- a/policy_test.go
+++ b/policy_test.go
@@ -223,7 +223,7 @@ func TestLimitPolicyLimit(t *testing.T) {
 	}
 }
 
-func TestLimitPolicyString(t *testing.T) {
+func TestLimitPolicy_httpHeaderValue(t *testing.T) {
 	cases := []struct {
 		name        string
 		limitPolicy *limitPolicy
@@ -435,7 +435,7 @@ func TestLimitPolicyString(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := tc.limitPolicy.String()
+			got := tc.limitPolicy.httpHeaderValue()
 			assert.Equal(t, tc.expect, got)
 		})
 	}

--- a/quota.go
+++ b/quota.go
@@ -11,14 +11,14 @@ import (
 // Quota tracks the remaining number of requests that can be made within a time
 // period.
 type Quota struct {
-	limit     *Limit
+	limit     *Limited
 	used      uint64
 	expiresAt time.Time
 
 	mu sync.RWMutex
 }
 
-func (q *Quota) reset(l *Limit) {
+func (q *Quota) reset(l *Limited) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 

--- a/quota_test.go
+++ b/quota_test.go
@@ -18,11 +18,10 @@ func TestQuota_reset(t *testing.T) {
 	require.Equal(t, uint64(0), q.used)
 	require.True(t, q.Expiration().IsZero())
 
-	l := &Limit{
+	l := &Limited{
 		Resource:    "resource",
 		Action:      "action",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      time.Minute,
 	}
@@ -32,11 +31,10 @@ func TestQuota_reset(t *testing.T) {
 	assert.Equal(t, uint64(10), q.MaxRequests())
 	q.used = 5
 
-	l2 := &Limit{
+	l2 := &Limited{
 		Resource:    "resource",
 		Action:      "action",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 50,
 		Period:      time.Minute * 10,
 	}
@@ -47,11 +45,10 @@ func TestQuota_reset(t *testing.T) {
 }
 
 func TestQuotaConsume(t *testing.T) {
-	l := &Limit{
+	l := &Limited{
 		Resource:    "resource",
 		Action:      "action",
 		Per:         LimitPerTotal,
-		Unlimited:   false,
 		MaxRequests: 10,
 		Period:      time.Minute,
 	}
@@ -86,11 +83,10 @@ func TestQuotaExpired(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			l := &Limit{
+			l := &Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: 10,
 				Period:      tc.period,
 			}
@@ -150,11 +146,10 @@ func TestQuotaRemaining(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			l := &Limit{
+			l := &Limited{
 				Resource:    "resource",
 				Action:      "action",
 				Per:         LimitPerTotal,
-				Unlimited:   false,
 				MaxRequests: tc.maxRequests,
 				Period:      time.Minute,
 			}


### PR DESCRIPTION
When checking if a request should be allowed, the limiter now correctly
considers cases where the corresponding limits are set to unlimited.
There are a few scenarios where this might be the case:

1. If some, but not all of the Limits for a given resource and action
   are Unlimited, the Unlimited Limits are skipped, with no quota being
   created for them.
2. If all of the Limits for a given resource and action are Unlimited,
   they will all be skipped, and the request should be allowed. However,
   in this case there will be no Quota returned by Allow.
3. If all of the Limits for *all* resources and actions are Unlimited,
   an error is returned when creating the Limiter.