### PR TITLE
feat: Round up when reporting reset time in usage header

### DIFF
--- a/limiter.go
+++ b/limiter.go
@@ -5,6 +5,7 @@ package rate
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"sync"
 )
@@ -113,7 +114,7 @@ func (l *Limiter) SetUsageHeader(quota *Quota, header http.Header) {
 
 	header.Set(
 		l.usageHeader,
-		fmt.Sprintf("limit=%d, remaining=%d, reset=%d", quota.MaxRequests(), quota.Remaining(), int64(quota.ResetsIn().Seconds())),
+		fmt.Sprintf("limit=%d, remaining=%d, reset=%.0f", quota.MaxRequests(), quota.Remaining(), math.Ceil(quota.ResetsIn().Seconds())),
 	)
 }
 

--- a/limiter_test.go
+++ b/limiter_test.go
@@ -1234,7 +1234,7 @@ func TestSetUsageHeader(t *testing.T) {
 			},
 			nil,
 			DefaultUsageHeader,
-			`limit=50, remaining=40, reset=59`,
+			`limit=50, remaining=40, reset=60`,
 		},
 		{
 			"ValidPolicyAlternateHeader",
@@ -1252,7 +1252,7 @@ func TestSetUsageHeader(t *testing.T) {
 			},
 			nil,
 			"Usage-Header",
-			`limit=50, remaining=40, reset=59`,
+			`limit=50, remaining=40, reset=60`,
 		},
 		{
 			"NilQuota",


### PR DESCRIPTION
Previously this would truncate to the nearest integer which could result
in clients expecting a limit to reset earlier than it would.