### PR TITLE
IND-3835 enabling dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[chore] : "
+      
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: "[chore] : "


### PR DESCRIPTION
As per the memo: https://go.hashi.co/memo/eng-004,
Enabling the dependabot for identifying and updating the security and version updates in the repositories rather handling it manually.