### PR TITLE
Remove ip-compliance team from CODEOWNERS, transfer ownership to boundary team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,7 +2,7 @@
 # More on CODEOWNERS files: https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
 # Default owner
-* @hashicorp/team-ip-compliance @hashicorp/boundary @tmessi
+* @hashicorp/boundary @tmessi
 
 # Add override rules below. Each line is a file/folder pattern followed by one or more owners.
 # Being an owner means those groups or individuals will be added as reviewers to PRs affecting


### PR DESCRIPTION
## Summary
- Remove `@hashicorp/team-ip-compliance` as code owner
- `@hashicorp/boundary` and `@tmessi` remain as owners

Requested by IP compliance team to transfer repository ownership to the boundary team.